### PR TITLE
Use official OSI name in license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     version="0.1.0",
     description="Access to the Unicode Character Database (UCD)",
     url="https://github.com/dylan-profiler/tangled-up-in-unicode",
-    license="BSD 4-Clause",
+    license="BSD License",
     packages=find_packages("src"),
     package_dir={"": "src"},
     install_requires=[],


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.

See https://en.wikipedia.org/wiki/BSD_licenses#4-clause_license_(original_%22BSD_License%22)